### PR TITLE
accidentally removed line that writes durations to log file

### DIFF
--- a/exptools2/core/session.py
+++ b/exptools2/core/session.py
@@ -250,7 +250,7 @@ class Session:
         
         # Same for nr frames
         nr_frames = np.append(self.global_log.loc[nonresp_idx, 'nr_frames'].values[1:], self.nr_frames)
-        self.global_log.loc[nonresp_idx, 'nr_frames'] = nr_frames.astype(np.float).astype(np.float32)
+        self.global_log.loc[nonresp_idx, 'nr_frames'] = nr_frames.astype(float).astype(float)
 
         # Round for readability and save to disk
         self.global_log = self.global_log.round({'onset': 5, 'onset_abs': 5, 'duration': 5})

--- a/exptools2/core/session.py
+++ b/exptools2/core/session.py
@@ -246,7 +246,8 @@ class Session:
         last_phase_onset = self.global_log.loc[nonresp_idx, 'onset'].iloc[-1]
         dur_last_phase = self.exp_stop - last_phase_onset 
         durations = np.append(self.global_log.loc[nonresp_idx, 'onset'].diff().values[1:], dur_last_phase)
-
+        self.global_log.loc[nonresp_idx, 'duration'] = durations
+        
         # Same for nr frames
         nr_frames = np.append(self.global_log.loc[nonresp_idx, 'nr_frames'].values[1:], self.nr_frames)
         self.global_log.loc[nonresp_idx, 'nr_frames'] = nr_frames.astype(np.float).astype(np.float32)

--- a/exptools2/data/default_settings.yml
+++ b/exptools2/data/default_settings.yml
@@ -25,7 +25,7 @@ eyetracker:
   dot_size: 0.1  # in deg
   options:
     binocular_enabled: NO  # [YES]
-    heuristic_filter: 2  # [0, OFF, 1, ON]
+    heuristic_filter: 0  # [0, OFF, 1, ON]
     pupil_size_diameter: YES  # [NO]
     #simulate_head_camera: NO  # [YES]  # GIVES ERROR?
     #simulation_screen_distance

--- a/exptools2/data/default_settings.yml
+++ b/exptools2/data/default_settings.yml
@@ -24,7 +24,6 @@ eyetracker:
   address: '100.1.1.1'
   dot_size: 0.1  # in deg
   options:
-    active_eye: left  # [right]
     binocular_enabled: NO  # [YES]
     heuristic_filter: 2  # [0, OFF, 1, ON]
     pupil_size_diameter: YES  # [NO]


### PR DESCRIPTION
During the previous merge we accidentally removed a line that write the `durations` to the log file, causing that field to be empty. This pull requests reverts that mistake. My bad.